### PR TITLE
Use SCIDB_VER to build the SCIDB_3RDPARTY path in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,19 @@ ifeq ($(SCIDB),)
   endif
 endif
 
+# A way to set the 3rdparty prefix path that is convenient
+# for SciDB developers.
+ifeq ($(SCIDB_VER),)
+  SCIDB_3RDPARTY = $(SCIDB)
+else
+  SCIDB_3RDPARTY = /opt/scidb/$(SCIDB_VER)
+endif
+
+# A better way to set the 3rdparty prefix path that does
+# not assume an absolute path. You can still use the above
+# method if you prefer.
 ifeq ($(SCIDB_THIRDPARTY_PREFIX),) 
-  SCIDB_THIRDPARTY_PREFIX := $(SCIDB)
+  SCIDB_THIRDPARTY_PREFIX := $(SCIDB_3RDPARTY)
 endif
 
 $(info Using SciDB path $(SCIDB))


### PR DESCRIPTION
SciDB can be installed in a custom directory. The 3rd party SciDB packages always install in `/opt/scidb`. In the `Makefile` the SciDB install path is used to build the path for the 3rd party SciDB packages. So, it will not use the correct path if SciDB is *not* installed in `/opt/scidb`.

For example, if SciDB is installed in `/usr/local/scidb`, this is the output of the `make` command:
```
$ make
Using SciDB path /usr/local/scidb
"/usr/bin/g++-4.9" -pedantic -W -Wextra -Wall -Wno-variadic-macros -Wno-strict-aliasing -Wno-long-long -Wno-unused-parameter -fPIC -DSCIDB_VARIANT=1507 -O2 -DNDEBUG -std=c++11 -DCPP11 -I. -DPROJECT_ROOT="\"/usr/local/scidb\"" -I"/usr/local/scidb/3rdparty/boost/include/" -I"/usr/local/scidb/include" -I./extern -o Logicalinstall_github.o -c Logicalinstall_github.cpp
In file included from Logicalinstall_github.cpp:1:0:
/usr/local/scidb/include/query/Operator.h:46:28: fatal error: boost/format.hpp: No such file or directory
 #include <boost/format.hpp>
                            ^
compilation terminated.
Makefile:56: recipe for target 'libdev_tools.so' failed
make: *** [libdev_tools.so] Error 1
```
Notice the path used for the 3rd party SciDB packages, `/usr/local/scidb/3rdparty/boost/include/`. The missing file actually exists in the expected location:
```
$ find / -type f -name format.hpp
/opt/scidb/15.7/3rdparty/boost/include/boost/format.hpp
...
```
This patch uses `SCIDB_VER` to build the `SCIDB_3RDPARTY` path. This is the same construct used in the [Makefile](https://github.com/Paradigm4/limit/blob/master/src/Makefile#L11) of the `limit` operator.

With this patch, the output of the `make` command is:
```
$ make
Using SciDB path /usr/local/scidb
"/usr/bin/g++-4.9" -pedantic -W -Wextra -Wall -Wno-variadic-macros -Wno-strict-aliasing -Wno-long-long -Wno-unused-parameter -fPIC -DSCIDB_VARIANT=1507 -O2 -DNDEBUG -std=c++11 -DCPP11 -I. -DPROJECT_ROOT="\"/usr/local/scidb\"" -I"/opt/scidb/15.7/3rdparty/boost/include/" -I"/usr/local/scidb/include" -I./extern -o Logicalinstall_github.o -c Logicalinstall_github.cpp
...
```
Notice the correct path for the 3rd party SciDB libraries, `/opt/scidb/15.7/3rdparty/boost/include/`.