### PR TITLE
Ability to specify proxy for wget

### DIFF
--- a/Physicalinstall_github.cpp
+++ b/Physicalinstall_github.cpp
@@ -113,7 +113,9 @@ fprintf(stderr, "cmd %s\n",cmd);
 // Get our base SciDB path (XXX is there an easier way?), and build the plugin
             memset(cmd,0,CMDBUFSZ);
             pid_t mypid = getpid();
-            snprintf(cmd,CMDBUFSZ,"x=`readlink /proc/%d/exe`;x=`dirname $x`;x=`dirname $x`;cd %s; tar -zxf *;cd %s/*-%s;SCIDB=$x %s make && tar -zcf ../plugin.tar.gz *.so",mypid,dir,dir,branch.c_str(), options.c_str());
+            std::string branch_dir_suffix = branch;
+            if (branch[0] == 'v') branch_dir_suffix = branch.substr(1);
+            snprintf(cmd,CMDBUFSZ,"x=`readlink /proc/%d/exe`;x=`dirname $x`;x=`dirname $x`;cd %s; tar -zxf *;cd %s/*-%s;SCIDB=$x %s make && tar -zcf ../plugin.tar.gz *.so",mypid,dir,dir,branch_dir_suffix.c_str(), options.c_str());
             k = ::system((const char *)cmd);
             if(k!=0) throw SYSTEM_EXCEPTION(SCIDB_SE_OPERATOR, SCIDB_LE_ILLEGAL_OPERATION)
                         << "failed to build plugin";

--- a/Physicalinstall_github.cpp
+++ b/Physicalinstall_github.cpp
@@ -104,7 +104,7 @@ public:
             d = mkdtemp(dir);
             if(!d) throw SYSTEM_EXCEPTION(SCIDB_SE_OPERATOR, SCIDB_LE_ILLEGAL_OPERATION)
                         << "failed to create temp directory";
-            snprintf(cmd,CMDBUFSZ,"cd %s && wget https://github.com/%s/archive/%s.tar.gz",dir,repo.c_str(),branch.c_str());
+            snprintf(cmd,CMDBUFSZ,"cd %s && %s wget https://github.com/%s/archive/%s.tar.gz",dir,options.c_str(),repo.c_str(),branch.c_str());
 fprintf(stderr, "cmd %s\n",cmd);
             k = ::system((const char *)cmd);
             if(k!=0) throw SYSTEM_EXCEPTION(SCIDB_SE_OPERATOR, SCIDB_LE_ILLEGAL_OPERATION)


### PR DESCRIPTION
If a proxy is required for `wget`, the `install_github` operator will fail. The `iquery` output looks like this:
```
AFL% load_library('dev_tools');
Query was executed successfully
AFL% install_github('Paradigm4/grouped_aggregate');
SystemException in file: Physicalinstall_github.cpp function: execute line: 110
Error id: scidb::SCIDB_SE_OPERATOR::SCIDB_LE_ILLEGAL_OPERATION
Error description: Operator error. Illegal operation: failed to retrieve repository.
```
The `scidb-stderr.log` will contain:
```
cmd cd /tmp/install_github_Zha58G && wget https://github.com/Paradigm4/grouped_aggregate/archive/master.tar.gz
converted 'https://github.com/Paradigm4/grouped_aggregate/archive/master.tar.gz' (ANSI_X3.4-1968) -> 'https://github.com/Paradigm4/grouped_aggregate/archive/master.tar.gz' (UTF-8)
--2016-04-04 20:54:51--  https://github.com/Paradigm4/grouped_aggregate/archive/master.tar.gz
Resolving github.com (github.com)... 192.30.252.123
Connecting to github.com (github.com)|192.30.252.123|:443... connected.
ERROR: The certificate of 'github.com' is not trusted.
ERROR: The certificate of 'github.com' hasn't got a known issuer.
The certificate's owner does not match hostname 'github.com'
```
This is not a certificate error, but a proxy error. Outside SciDB, setting the `https_proxy` variable in the environment would make the `wget` command to succeed:
```
$ https_proxy=https://...proxy... wget https://github.com/Paradigm4/grouped_aggregate/archive/master.tar.gz
converted 'https://github.com/Paradigm4/grouped_aggregate/archive/master.tar.gz' (ANSI_X3.4-1968) -> 'https://github.com/Paradigm4/grouped_aggregate/archive/master.tar.gz' (UTF-8)
--2016-04-04 20:57:08--  https://github.com/Paradigm4/grouped_aggregate/archive/master.tar.gz
Resolving ...proxy...
Connecting to ...proxy...connected.
Proxy request sent, awaiting response... 302 Found
Location: https://codeload.github.com/Paradigm4/grouped_aggregate/tar.gz/master [following]
converted 'https://codeload.github.com/Paradigm4/grouped_aggregate/tar.gz/master' (ANSI_X3.4-1968) -> 'https://codeload.github.com/Paradigm4/grouped_aggregate/tar.gz/master' (UTF-8)
--2016-04-04 20:57:09--  https://codeload.github.com/Paradigm4/grouped_aggregate/tar.gz/master
Connecting to ...proxy... connected.
Proxy request sent, awaiting response... 200 OK
Length: unspecified [application/x-gzip]
Saving to: 'master.tar.gz'

master.tar.gz                                  [ <=>                                                                                    ]  16.77K  --.-KB/s   in 0.08s  

2016-04-04 20:57:09 (200 KB/s) - 'master.tar.gz' saved [17172]
```
This patch uses the environment variables provided in the `options` argument of the `install_github` operator when running the `wget` command. The environment variables are placed in from of the `wget` command. So, to specify a proxy in the `install_github` operator one could use:
```
install_github('Paradigm4/grouped_aggregate, 'https_proxy=https://...')
```
---
An alternative, which does not require this patch, is to set the proxy in the `/etc/wgetrc` file, for example:
```
$ cat /etc/wgetrc 
...
https_proxy=https://...
```
